### PR TITLE
Upgrade remoting to 2.62

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM java:8-jdk
 
-RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/2.60/remoting-2.60.jar \
+RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/2.62/remoting-2.62.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@
 
 FROM java:8-jdk
 
-RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/2.52/remoting-2.52.jar \
+RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar http://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/2.60/remoting-2.60.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar
 


### PR DESCRIPTION
This fix upgrades remoting to 2.60, which is the latest version.

There are much changes since 2.52. The major ones are:
* Support of the JNLP3 protocol with encryption
* Memory leak fixes
* Fixes for several connectivity issues

Incomplete changelog is available here: https://github.com/jenkinsci/remoting/blob/stable-2.x/CHANGELOG.md

@reviewbybees @jenkinsci/code-reviewers 