### PR TITLE
Remoting/3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV HOME /home/jenkins
 RUN groupadd -g 10000 jenkins
 RUN useradd -c "Jenkins user" -d $HOME -u 10000 -g 10000 -m jenkins
 
-ARG VERSION=2.62
+ARG VERSION=3.5
 
 RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The MIT License
 #
-#  Copyright (c) 2015, CloudBees, Inc.
+#  Copyright (c) 2015-2017, CloudBees, Inc. and other Jenkins contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ MAINTAINER Nicolas De Loof <nicolas.deloof@gmail.com>
 ENV HOME /home/jenkins
 RUN groupadd -g 10000 jenkins
 RUN useradd -c "Jenkins user" -d $HOME -u 10000 -g 10000 -m jenkins
+LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="3.5"
 
 ARG VERSION=3.5
 


### PR DESCRIPTION
Changes summary:

* [x] [JENKINS-39922](https://issues.jenkins-ci.org/browse/JENKINS-39922) - Update the Jenkins agent executable to the latest version
 - Remoting 3.x is still compatible with old Jenkins masters working on Java 7 or above (1.610 +)
 - This version introduces the new encrypted (JNLP4 protocol](https://github.com/jenkinsci/remoting/blob/master/docs/protocols.md#jnlp4-connect)
 - Picked many bugfixes
 - [Full Changelog](https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md)
* [x] Update the image metadata a bit

## Compatibility notes

Java 6 support is dropped in Remoting 3.x. If somebody uses Docker agents with Java 6 masters, we could create another image with Remoting 2.x stable.

@reviewbybees

