### PR TITLE
Create README for the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+Jenkins Agent Docker image
+===
+
+[![Docker Stars](https://img.shields.io/docker/stars/jenkinsci/slave.svg)](https://hub.docker.com/r/jenkinsci/slave/)
+[![Docker Pulls](https://img.shields.io/docker/pulls/jenkinsci/slave.svg)](https://hub.docker.com/r/jenkinsci/slave/)
+[![Docker Automated build](https://img.shields.io/docker/automated/jenkinsci/slave.svg)](https://hub.docker.com/r/jenkinsci/slave/)
+
+This is a base image for Docker, which includes OpenJDK 8 and the Jenkins agent executable (slave.jar).
+This executable is an instance of the [Jenkins Remoting library](https://github.com/jenkinsci/remoting).
+
+## Usage
+
+This image is being used in the [Docker JNLP Agent](https://github.com/jenkinsci/docker-jnlp-slave/) image.
+
+## Configurations
+
+The image has several supported configurations, which can be accessed via the following tags:
+
+* `latest`: Latest version with the newest remoting (based on `openjdk:8-jdk`)
+* `alpine`: Small image based on Alpine Linux (based on `openjdk:8-jdk-alpine`)
+* `2.62`: This version bundles [Remoting 2.x](https://github.com/jenkinsci/remoting#remoting-2]), which is compatible with Jenkins servers running on Java 6 (`1.609.4` and below)
+* `2.62-alpine`: Small image with Remoting 2.x


### PR DESCRIPTION
This PR creates a Readme for the current state of the DockerHub. `2.62` branches need to be revived in the repository since we have automatic builds now. Maybe it's better to rename them to something like `2.x` and `2.x-alpine` since @jglick wants to change the version naming approach in Remoting 2.x

<img width="622" alt="screen shot 2017-03-15 at 10 17 34" src="https://cloud.githubusercontent.com/assets/3000480/23941356/ce43f304-0968-11e7-9f6c-848c850dcaa0.png">

@reviewbybees, esp. @ndeloof and @carlossg 
