### PR TITLE
[JENKINS-41137] Add openssh-client for git clone from ssh to work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ LABEL Description="This is a base image, which provides the Jenkins agent execut
 
 ARG VERSION=3.7
 
-RUN apk add --update --no-cache curl bash git \
+RUN apk add --update --no-cache curl bash git openssh-client \
   && curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar \


### PR DESCRIPTION
Otherwise git clone fails in alpine

https://issues.jenkins-ci.org/browse/JENKINS-41137

```
$ docker run -ti --rm --entrypoint git jenkins/slave:alpine clone git@github.com:carlossg/selenium-example.git
Cloning into 'selenium-example'...
error: cannot run ssh: No such file or directory
fatal: unable to fork
```
