### PR TITLE
Add openssl to alpine to allow downloads from https sites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ LABEL Description="This is a base image, which provides the Jenkins agent execut
 
 ARG VERSION=3.7
 
-RUN apk add --update --no-cache curl bash git openssh-client \
+RUN apk add --update --no-cache curl bash git openssh-client openssl \
   && curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar \


### PR DESCRIPTION
With master image it works

```
$ docker run -ti --rm jenkinsci/slave:3.7-1 wget https://www.google.com
--2017-06-11 11:39:53--  https://www.google.com/
Resolving www.google.com (www.google.com)... 216.58.198.36, 2a00:1450:4002:807::2004
Connecting to www.google.com (www.google.com)|216.58.198.36|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://www.google.es/?gfe_rd=cr&ei=CSw9WceLPMbA8geCooOYBg [following]
--2017-06-11 11:39:53--  https://www.google.es/?gfe_rd=cr&ei=CSw9WceLPMbA8geCooOYBg
Resolving www.google.es (www.google.es)... 216.58.205.67, 2a00:1450:4002:808::2003
Connecting to www.google.es (www.google.es)|216.58.205.67|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [text/html]
Saving to: ‘index.html’

index.html                               [ <=>                                                                   ]  11.41K  --.-KB/s   in 0.002s

2017-06-11 11:39:54 (4.96 MB/s) - ‘index.html’ saved [11685]
```

with alpine image it doesn't

```
$ docker run -ti --rm jenkinsci/slave:3.7-1-alpine wget https://www.google.com
Connecting to www.google.com (216.58.198.36:443)
wget: can't execute 'ssl_helper': No such file or directory
wget: error getting response: Connection reset by peer
```

with the patch it does

```
$ docker run -ti --rm jenkinsci/slave:alpine wget https://www.google.com
Connecting to www.google.com (216.58.198.36:443)
Connecting to www.google.es (216.58.205.67:443)
index.html           100% |*************************************************************************************************| 11717   0:00:00 ETA
```