### PR TITLE
Create Jenkins workspace folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,6 @@ RUN apk add --update --no-cache curl bash git openssh-client openssl \
   && apk del curl
 
 USER jenkins
-RUN mkdir /home/jenkins/.jenkins
+RUN mkdir /home/jenkins/.jenkins /home/jenkins/workspace
 VOLUME /home/jenkins/.jenkins
 WORKDIR /home/jenkins


### PR DESCRIPTION
Only way I have been able to mount a Docker volume (docker volume create jenkins-workspace) from the host as workspace directory with the right permissions. Without an existing workspace directory owned by the Jenkins user Docker mounts the workspace directory as root and hence the Jenkins users lacks permissions to use the workspace directory.