### PR TITLE
[JENKINS-44114] - Update to remoting 3.10 and add workdir support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,14 +28,17 @@ RUN groupadd -g 10000 jenkins
 RUN useradd -c "Jenkins user" -d $HOME -u 10000 -g 10000 -m jenkins
 LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="3.7"
 
-ARG VERSION=3.7
+ARG VERSION=3.10
+ARG AGENT_WORKDIR=/home/jenkins/agent
 
 RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar
 
-
 USER jenkins
-RUN mkdir /home/jenkins/.jenkins
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+RUN mkdir /home/jenkins/.jenkins && mkdir -p ${AGENT_WORKDIR}
+
 VOLUME /home/jenkins/.jenkins
+VOLUME ${AGENT_WORKDIR}
 WORKDIR /home/jenkins

--- a/README.md
+++ b/README.md
@@ -19,7 +19,18 @@ This image may instead be used to launch an agent using the **Launch method** of
 docker run -i --rm --name agent jenkinsci/slave:3.7-1 java -jar /usr/share/jenkins/slave.jar
 ```
 
-after setting **Remote root directory** to `/home/jenkins`.
+after setting **Remote root directory** to `/var/lib/jenkins/agent`.
+
+### Agent Work Directories
+
+Starting from [Remoting 3.8](https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md#38) there is a support of Work directories, 
+which provides logging by default and change the JAR Caching behavior.
+
+Call example:
+
+```sh
+docker run -i --rm --name agent1 --v agent1-workdir:/home/jenkins/agent jenkinsci/slave:3.10-1 java -jar /usr/share/jenkins/slave.jar -workDir /home/jenkins/agent
+```
 
 ## Configurations
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This image may instead be used to launch an agent using the **Launch method** of
 docker run -i --rm --name agent jenkinsci/slave:3.7-1 java -jar /usr/share/jenkins/slave.jar
 ```
 
-after setting **Remote root directory** to `/var/lib/jenkins/agent`.
+after setting **Remote root directory** to `/home/jenkins/agent`.
 
 ### Agent Work Directories
 


### PR DESCRIPTION
- [x] - Upgrade Remoting from 3.7 to 3.10 ([Changelog](https://github.com/jenkinsci/remoting/blob/master/CHANGELOG.md)). It includes some bugfixes, improves logging options, and ads Work Directory support
- [x] - Reserve a space for Remoting Work Directory and expand it as a volume
- [x] - Document usage of Work directories in README

@reviewbybees