### PR TITLE
[JENKINS-51986] - Introduce a Java 11 packaging for the Debian image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-FROM openjdk:8-jdk
+FROM openjdk:11-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
 ARG user=jenkins


### PR DESCRIPTION
It creates a branch for Java 11 and Remoting. Apparently works as is

https://issues.jenkins-ci.org/browse/JENKINS-51986
