### PR TITLE
Fixed Jenkins UID and GID to be consistent with the Jenkins Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
 ARG user=jenkins
 ARG group=jenkins
-ARG uid=10000
-ARG gid=10000
+ARG uid=1000
+ARG gid=1000
 
 ENV HOME /home/${user}
 RUN groupadd -g ${gid} ${group}


### PR DESCRIPTION
The Jenkins UID and GID has to be same as the Jenkins Docker image otherwise Docker-in-Docker can not be used, by mounting `/var/run/docker.sock`.

Jenkins Docker image settings: https://github.com/jenkinsci/docker/blob/master/Dockerfile#L7

Resolves #32 