### PR TITLE
Merge branches

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -23,6 +23,7 @@
 FROM openjdk:8-jdk-alpine
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
+ARG VERSION=3.28
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
@@ -31,9 +32,7 @@ ARG gid=1000
 ENV HOME /home/${user}
 RUN addgroup -g ${gid} ${group}
 RUN adduser -h $HOME -u ${uid} -G ${group} -D ${user}
-LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="3.27"
-
-ARG VERSION=3.27
+LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG AGENT_WORKDIR=/home/${user}/agent
 

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -23,7 +23,6 @@
 FROM openjdk:11-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.28
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
@@ -32,11 +31,12 @@ ARG gid=1000
 ENV HOME /home/${user}
 RUN groupadd -g ${gid} ${group}
 RUN useradd -c "Jenkins user" -d $HOME -u ${uid} -g ${gid} -m ${user}
-LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="${VERSION}"
+LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="3.27"
 
+ARG VERSION=3.27
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN curl --create-dirs -fsSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
+RUN curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+for dockerfile in Dockerfile*
+do
+    dockertag=$( echo "$dockerfile" | cut -d ' ' -f 2 )
+    if [[ "$dockertag" = "$dockerfile" ]]; then
+        dockertag='latest'
+    fi
+    echo "Building $dockerfile => tag=$dockertag"
+    docker build -t jenkins/slave:$dockertag .
+    docker build -t jenkins/agent:$dockertag .
+done
+
+echo "Build finished successfully"


### PR DESCRIPTION
Following up on https://github.com/jenkinsci/docker-slave/pull/38#issuecomment-445197261 and agreement there from @carlossg for instance. 

I propose in this PR to merge all branches into a single one and many Dockerfiles. This will make aligning variants much simpler, instead of having to file 3 PRs like https://github.com/jenkinsci/docker-slave/pull/38.

Also created a small `build.sh` which I'll call from a `Jenkinsfile` as soon as https://issues.jenkins-ci.org/browse/INFRA-1857 gets looked at by @olblak or someone else with sufficient permissions.

**Once this is merged, we will delete the branches and keep only `master` to avoid ambiguity for contributors.**