### PR TITLE
Add tini to Dockerfile alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ ARG VERSION=3.27
 
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN apk add --update --no-cache curl bash git openssh-client openssl procps \
+RUN apk add --update --no-cache curl bash git openssh-client openssl procps tini \
   && curl --create-dirs -sSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/slave.jar \


### PR DESCRIPTION
Install `tini` as `jenkinsci/docker` images do in order to child images use it.