### PR TITLE
[JENKINS-42846] - Rename slave.jar to agent.jar, keep symbolic link for compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG AGENT_WORKDIR=/home/${user}/agent
 
 RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
 RUN apt-get update && apt-get install -t stretch-backports git-lfs
-RUN curl --create-dirs -fsSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
+RUN curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/agent.jar \
   && ln -sf /usr/share/jenkins/slave.jar /usr/share/jenkins/agent.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ ARG AGENT_WORKDIR=/home/${user}/agent
 RUN curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
   && chmod 644 /usr/share/jenkins/agent.jar
+RUN ln -sf /usr/share/jenkins/slave.jar /usr/share/jenkins/agent.jar
 
 USER ${user}
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,13 +32,13 @@ ARG gid=1000
 ENV HOME /home/${user}
 RUN groupadd -g ${gid} ${group}
 RUN useradd -c "Jenkins user" -d $HOME -u ${uid} -g ${gid} -m ${user}
-LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="${VERSION}"
+LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG AGENT_WORKDIR=/home/${user}/agent
 
-RUN curl --create-dirs -fsSLo /usr/share/jenkins/slave.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
+RUN curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
   && chmod 755 /usr/share/jenkins \
-  && chmod 644 /usr/share/jenkins/slave.jar
+  && chmod 644 /usr/share/jenkins/agent.jar
 
 USER ${user}
 ENV AGENT_WORKDIR=${AGENT_WORKDIR}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Jenkins Agent Docker image
 [![Docker Pulls](https://img.shields.io/docker/pulls/jenkins/slave.svg)](https://hub.docker.com/r/jenkins/slave/)
 [![Docker Automated build](https://img.shields.io/docker/automated/jenkins/slave.svg)](https://hub.docker.com/r/jenkins/slave/)
 
-This is a base image for Docker, which includes OpenJDK 8 and the Jenkins agent executable (slave.jar).
+This is a base image for Docker, which includes OpenJDK 8 and the Jenkins agent executable (agent.jar).
 This executable is an instance of the [Jenkins Remoting library](https://github.com/jenkinsci/remoting).
 
 ## Usage
@@ -16,7 +16,7 @@ In that image, the container is launched externally and attaches to Jenkins.
 This image may instead be used to launch an agent using the **Launch method** of **Launch agent via execution of command on the master**. Try for example
 
 ```sh
-docker run -i --rm --name agent --init jenkins/slave java -jar /usr/share/jenkins/slave.jar
+docker run -i --rm --name agent --init jenkins/slave java -jar /usr/share/jenkins/agent.jar
 ```
 
 after setting **Remote root directory** to `/home/jenkins/agent`.
@@ -29,7 +29,7 @@ which provides logging by default and change the JAR Caching behavior.
 Call example:
 
 ```sh
-docker run -i --rm --name agent1 --init -v agent1-workdir:/home/jenkins/agent jenkins/slave java -jar /usr/share/jenkins/slave.jar -workDir /home/jenkins/agent
+docker run -i --rm --name agent1 --init -v agent1-workdir:/home/jenkins/agent jenkins/slave java -jar /usr/share/jenkins/agent.jar -workDir /home/jenkins/agent
 ```
 
 ## Configurations


### PR DESCRIPTION
Renamed the slave.jars to agent .jars.  I wasn't sure how to update the location of this image on docker hub to jenkins/agent. 