### PR TITLE
Drop global HOME environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,8 @@ ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
 
-ENV HOME /home/${user}
 RUN groupadd -g ${gid} ${group}
-RUN useradd -c "Jenkins user" -d $HOME -u ${uid} -g ${gid} -m ${user}
+RUN useradd -c "Jenkins user" -d /home/${user} -u ${uid} -g ${gid} -m ${user}
 LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG AGENT_WORKDIR=/home/${user}/agent

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -29,9 +29,8 @@ ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
 
-ENV HOME /home/${user}
 RUN addgroup -g ${gid} ${group}
-RUN adduser -h $HOME -u ${uid} -G ${group} -D ${user}
+RUN adduser -h /home/${user} -u ${uid} -G ${group} -D ${user}
 LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG AGENT_WORKDIR=/home/${user}/agent

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -29,9 +29,8 @@ ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
 
-ENV HOME /home/${user}
 RUN groupadd -g ${gid} ${group}
-RUN useradd -c "Jenkins user" -d $HOME -u ${uid} -g ${gid} -m ${user}
+RUN useradd -c "Jenkins user" -d /home/${user} -u ${uid} -g ${gid} -m ${user}
 LABEL Description="This is a base image, which provides the Jenkins agent executable (slave.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG AGENT_WORKDIR=/home/${user}/agent


### PR DESCRIPTION
HOME is normally controlled by the "system"[1] and should match what the user's home directory in `/etc/passwd` is. Overwriting this value with `ENV` in this docker image causes some surprises when the user is changes with `USER` in a docker image derived `FROM` this image. Unfortunatly, docker still doesn't allow to "reset" environment variables (https://github.com/moby/moby/issues/3465), so if I want to change the user, I need to remember to also update `HOME`.

Long story short: This removes the global preset for `HOME`, so `HOME` does function as expected.

[1] I think in normal UNIX sessions, login is responsible for that, but in the case of docker, docker itself takes care of that..