### PR TITLE
Update Remoting from 3.29 to 3.35

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 FROM openjdk:8-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.29
+ARG VERSION=3.34
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 FROM openjdk:8-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.34
+ARG VERSION=3.35
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000


### PR DESCRIPTION
The [latest version](https://github.com/jenkinsci/remoting/releases/tag/remoting-3.34) of `remoting` contains changes allowing to connect to a headless Jenkins like Jenkinsfile Runner.
We need this to run Jenkinsfile Runner on Kubernetes in combination with the Kubernetes plugin.

@jeffret-b @oleg-nenashev 