### PR TITLE
Fix Windows container paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The image has several supported configurations, which can be accessed via the fo
 * `latest`: Latest version with the newest remoting (based on `openjdk:8-jdk`)
 * `latest-jdk11`: Latest version with the newest remoting and Java 11 (based on `openjdk:11-jdk`)
 * `alpine`: Small image based on Alpine Linux (based on `openjdk:8-jdk-alpine`)
-* `latest-windows`: Latest version with the newest remoting (based on `openjdk:8-jdk-windowsservercore-1809`)
-* `latest-windows-jdk11`: Latest version with the newest remoting and Java 11 (based on `openjdk:11.0-jdk-windowsservercore-1809`)
+* `jenkins4eval/agent:latest-windows`: Latest version with the newest remoting (based on `openjdk:8-jdk-windowsservercore-1809`)
+* `jenkins4eval/agent:latest-windows-jdk11`: Latest version with the newest remoting and Java 11 (based on `openjdk:11.0-jdk-windowsservercore-1809`)
 * `2.62`: This version bundles [Remoting 2.x](https://github.com/jenkinsci/remoting#remoting-2]), which is compatible with Jenkins servers running on Java 6 (`1.609.4` and below)
 * `2.62-alpine`: Small image with Remoting 2.x
 * `2.62-jdk11`: Versioned image for Java 11


### PR DESCRIPTION
Use full id for the Windows containers until they are in the jenkins dockerhub org.