### PR TITLE
Don't build on trusted and image cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,6 +34,8 @@ pipeline {
                             infra.withDockerCredentials {
                                 powershell '& ./make.ps1 publish'
                             }
+                            
+                            powershell '& docker system prune --force --all'
                         }
                     }
                 }
@@ -47,7 +49,7 @@ pipeline {
                     steps {
                         script {
                             if(!infra.isTrusted()) {
-                                sh './build.sh'
+                                sh './build.sh ; docker system prune --force --all'
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,11 @@ pipeline {
                         timeout(time: 30, unit: 'MINUTES')
                     }
                     steps {
-                        sh './build.sh'
+                        script {
+                            if(!infra.isTrusted()) {
+                                sh './build.sh'
+                            }
+                        }
                     }
                 }
             }

--- a/make.ps1
+++ b/make.ps1
@@ -58,6 +58,4 @@ if($lastExitCode -ne 0) {
 } else {
     Write-Host "Build finished successfully"
 }
-Write-Host "Cleaning up docker images..."
-& docker system prune --force --all
 exit $lastExitCode


### PR DESCRIPTION
The build occurs on the docker hub builds, so we don't need to build and push on trusted.