### PR TITLE
Use remoting 3.36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 FROM openjdk:8-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.35
+ARG VERSION=3.36
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -23,7 +23,7 @@
 FROM openjdk:8-jdk-alpine
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.35
+ARG VERSION=3.36
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -23,7 +23,7 @@
 FROM openjdk:11-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.35
+ARG VERSION=3.36
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -29,7 +29,7 @@ MAINTAINER Alex Earl <slide.o.mix@gmail.com>
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=3.35
+ARG VERSION=3.36
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.24.0

--- a/Dockerfile-windows-jdk11
+++ b/Dockerfile-windows-jdk11
@@ -29,7 +29,7 @@ MAINTAINER Alex Earl <slide.o.mix@gmail.com>
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=3.35
+ARG VERSION=3.36
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.24.0

--- a/Dockerfile-windows-nanoserver
+++ b/Dockerfile-windows-nanoserver
@@ -63,7 +63,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Remove-Item mingit.zip -Force ; `
     setx /M PATH $('c:\mingit\cmd;{0}' -f $env:PATH)
 
-ARG VERSION=3.35
+ARG VERSION=3.36
 ARG user=jenkins
 
 ARG AGENT_FILENAME=agent.jar

--- a/Dockerfile-windows-nanoserver-jdk11
+++ b/Dockerfile-windows-nanoserver-jdk11
@@ -63,7 +63,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Remove-Item mingit.zip -Force ; `
     setx /M PATH $('c:\mingit\cmd;{0}' -f $env:PATH)
 
-ARG VERSION=3.35
+ARG VERSION=3.36
 ARG user=jenkins
 
 ARG AGENT_FILENAME=agent.jar

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Jenkins Agent Docker image
 [![Docker Stars](https://img.shields.io/docker/stars/jenkins/slave.svg)](https://hub.docker.com/r/jenkins/slave/)
 [![Docker Pulls](https://img.shields.io/docker/pulls/jenkins/slave.svg)](https://hub.docker.com/r/jenkins/slave/)
 [![Docker Automated build](https://img.shields.io/docker/automated/jenkins/slave.svg)](https://hub.docker.com/r/jenkins/slave/)
-[![GitHub release](https://img.shields.io/github/release/jenkinsci/docker-slave.svg?label=chanelog)](https://github.com/jenkinsci/docker-slave/releases/latest)
+[![GitHub release](https://img.shields.io/github/release/jenkinsci/docker-slave.svg?label=changelog)](https://github.com/jenkinsci/docker-slave/releases/latest)
 
 This is a base image for Docker, which includes JDK and the Jenkins agent executable (agent.jar).
 This executable is an instance of the [Jenkins Remoting library](https://github.com/jenkinsci/remoting).


### PR DESCRIPTION
## Use remoting 3.36

Jenkins 2.204.1 LTS includes remoting 3.36

Tested default (Debian 9), Alpine Linux, and JDK 11.

Did not test Windows images, though I have tested Windows agents using remoting 3.36 with both JNLP and ssh connections.