### PR TITLE
Update to Remoting 3.40.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 FROM openjdk:8-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.36
+ARG VERSION=3.40
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The MIT License
 #
-#  Copyright (c) 2015-2019, CloudBees, Inc. and other Jenkins contributors
+#  Copyright (c) 2015-2020, CloudBees, Inc. and other Jenkins contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,6 +1,6 @@
 # The MIT License
 #
-#  Copyright (c) 2015-2019, CloudBees, Inc. and other Jenkins contributors
+#  Copyright (c) 2015-2020, CloudBees, Inc. and other Jenkins contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -23,7 +23,7 @@
 FROM openjdk:8-jdk-alpine
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.36
+ARG VERSION=3.40
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -1,6 +1,6 @@
 # The MIT License
 #
-#  Copyright (c) 2015-2019, CloudBees, Inc. and other Jenkins contributors
+#  Copyright (c) 2015-2020, CloudBees, Inc. and other Jenkins contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -23,7 +23,7 @@
 FROM openjdk:11-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=3.36
+ARG VERSION=3.40
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -29,7 +29,7 @@ MAINTAINER Alex Earl <slide.o.mix@gmail.com>
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=3.36
+ARG VERSION=3.40
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.24.0

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -2,7 +2,7 @@
 
 # The MIT License
 #
-#  Copyright (c) 2020, Alex Earl and other Jenkins Contributors
+#  Copyright (c) 2019-2020, Alex Earl and other Jenkins Contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -2,7 +2,7 @@
 
 # The MIT License
 #
-#  Copyright (c) 2019, Alex Earl and other Jenkins Contributors
+#  Copyright (c) 2020, Alex Earl and other Jenkins Contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/Dockerfile-windows-jdk11
+++ b/Dockerfile-windows-jdk11
@@ -29,7 +29,7 @@ MAINTAINER Alex Earl <slide.o.mix@gmail.com>
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=3.36
+ARG VERSION=3.40
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.24.0

--- a/Dockerfile-windows-jdk11
+++ b/Dockerfile-windows-jdk11
@@ -2,7 +2,7 @@
 
 # The MIT License
 #
-#  Copyright (c) 2019, Alex Earl and other Jenkins Contributors
+#  Copyright (c) 2020, Alex Earl and other Jenkins Contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/Dockerfile-windows-nanoserver
+++ b/Dockerfile-windows-nanoserver
@@ -63,7 +63,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Remove-Item mingit.zip -Force ; `
     setx /M PATH $('c:\mingit\cmd;{0}' -f $env:PATH)
 
-ARG VERSION=3.36
+ARG VERSION=3.40
 ARG user=jenkins
 
 ARG AGENT_FILENAME=agent.jar

--- a/Dockerfile-windows-nanoserver
+++ b/Dockerfile-windows-nanoserver
@@ -2,7 +2,7 @@
 
 # The MIT License
 #
-#  Copyright (c) 2020, Alex Earl and other Jenkins Contributors
+#  Copyright (c) 2019-2020, Alex Earl and other Jenkins Contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/Dockerfile-windows-nanoserver
+++ b/Dockerfile-windows-nanoserver
@@ -2,7 +2,7 @@
 
 # The MIT License
 #
-#  Copyright (c) 2019, Alex Earl and other Jenkins Contributors
+#  Copyright (c) 2020, Alex Earl and other Jenkins Contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/Dockerfile-windows-nanoserver-jdk11
+++ b/Dockerfile-windows-nanoserver-jdk11
@@ -63,7 +63,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Remove-Item mingit.zip -Force ; `
     setx /M PATH $('c:\mingit\cmd;{0}' -f $env:PATH)
 
-ARG VERSION=3.36
+ARG VERSION=3.40
 ARG user=jenkins
 
 ARG AGENT_FILENAME=agent.jar

--- a/Dockerfile-windows-nanoserver-jdk11
+++ b/Dockerfile-windows-nanoserver-jdk11
@@ -2,7 +2,7 @@
 
 # The MIT License
 #
-#  Copyright (c) 2019, Alex Earl and other Jenkins Contributors
+#  Copyright (c) 2020, Alex Earl and other Jenkins Contributors
 #
 #  Permission is hereby granted, free of charge, to any person obtaining a copy
 #  of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2015-2019 Jenkins project contributors
+Copyright (c) 2015-2020 Jenkins project contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This Remoting version removes old, deprecated, unsupported protocols versions 1, 2, and 3. And the unused plain protocol. See the [Remoting changelog](https://github.com/jenkinsci/remoting/releases) for full details.