### PR TITLE
Update to Remoting 4.0.1 for security release.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 FROM openjdk:8-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=4.0
+ARG VERSION=4.0.1
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -23,7 +23,7 @@
 FROM openjdk:8-jdk-alpine
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=4.0
+ARG VERSION=4.0.1
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -23,7 +23,7 @@
 FROM openjdk:11-jdk
 MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
-ARG VERSION=4.0
+ARG VERSION=4.0.1
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-windows
+++ b/Dockerfile-windows
@@ -29,7 +29,7 @@ MAINTAINER Alex Earl <slide.o.mix@gmail.com>
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=4.0
+ARG VERSION=4.0.1
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.24.0

--- a/Dockerfile-windows-jdk11
+++ b/Dockerfile-windows-jdk11
@@ -29,7 +29,7 @@ MAINTAINER Alex Earl <slide.o.mix@gmail.com>
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG VERSION=4.0
+ARG VERSION=4.0.1
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.24.0

--- a/Dockerfile-windows-nanoserver
+++ b/Dockerfile-windows-nanoserver
@@ -63,7 +63,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Remove-Item mingit.zip -Force ; `
     setx /M PATH $('c:\mingit\cmd;{0}' -f $env:PATH)
 
-ARG VERSION=4.0
+ARG VERSION=4.0.1
 ARG user=jenkins
 
 ARG AGENT_FILENAME=agent.jar

--- a/Dockerfile-windows-nanoserver-jdk11
+++ b/Dockerfile-windows-nanoserver-jdk11
@@ -63,7 +63,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Remove-Item mingit.zip -Force ; `
     setx /M PATH $('c:\mingit\cmd;{0}' -f $env:PATH)
 
-ARG VERSION=4.0
+ARG VERSION=4.0.1
 ARG user=jenkins
 
 ARG AGENT_FILENAME=agent.jar


### PR DESCRIPTION
See [SECURITY-1659](https://jenkins.io/security/advisory/2020-01-29/). Also see the [Remoting changelog](https://github.com/jenkinsci/remoting/releases/tag/remoting-4.0.1) (which says the same thing.)