### PR TITLE
Windows updates and cleanup

### DIFF
--- a/11/buster/Dockerfile
+++ b/11/buster/Dockerfile
@@ -21,7 +21,6 @@
 #  THE SOFTWARE.
 
 FROM openjdk:11-jdk-buster
-MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
 ARG VERSION=4.3
 ARG user=jenkins

--- a/11/stretch/Dockerfile
+++ b/11/stretch/Dockerfile
@@ -21,7 +21,6 @@
 #  THE SOFTWARE.
 
 FROM openjdk:11-jdk-stretch
-MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
 ARG VERSION=4.3
 ARG user=jenkins

--- a/11/windows/nanoserver-1809/Dockerfile
+++ b/11/windows/nanoserver-1809/Dockerfile
@@ -22,26 +22,18 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG WINDOWS_DOCKER_TAG=1809
-ARG JAVA_VERSION=11.0.6+10
-ARG JAVA_SHA256=6fb8b6c254ec0e1091acd421ac79c1bb07b295de0b679c0595fd284caf7734e5
-ARG JAVA_HOME=C:\jdk-${JAVA_VERSION}
 # If you pass in a POWERSHELL_VERSION, make sure it ends with a hyphen, leaving it empty will
 # use the 'latest'
 ARG POWERSHELL_VERSION=
+FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809
 
-FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-$WINDOWS_DOCKER_TAG
-MAINTAINER Alex Earl <slide.o.mix@gmail.com>
-
-ARG JAVA_VERSION
-ARG JAVA_SHA256
-ARG JAVA_HOME
+ARG JAVA_VERSION=11.0.6+10
+ARG JAVA_SHA256=6fb8b6c254ec0e1091acd421ac79c1bb07b295de0b679c0595fd284caf7734e5
+ARG JAVA_HOME=C:\jdk-${JAVA_VERSION}
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 USER ContainerAdministrator
-
-# https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_windows_hotspot_11.0.6_10.zip
 
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
     $javaRoot = 'OpenJDK11U-jdk_x64_windows_hotspot_{0}' -f $env:JAVA_VERSION.Replace('+', '_') ; `
@@ -52,9 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive openjdk.zip -DestinationPath C:/ ; `
     Remove-Item -Path openjdk.zip
 
-ARG JAVA_HOME
-
-ARG VERSION=4.0.1
+ARG VERSION=4.3
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.26.0

--- a/11/windows/windowsservercore-1809/Dockerfile
+++ b/11/windows/windowsservercore-1809/Dockerfile
@@ -22,10 +22,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG WINDOWS_DOCKER_TAG=1809
-
-FROM adoptopenjdk:11-jdk-hotspot-windowsservercore-$WINDOWS_DOCKER_TAG
-MAINTAINER Alex Earl <slide.o.mix@gmail.com>
+FROM adoptopenjdk:11-jdk-hotspot-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/8/alpine/Dockerfile
+++ b/8/alpine/Dockerfile
@@ -21,7 +21,6 @@
 #  THE SOFTWARE.
 
 FROM openjdk:8-jdk-alpine3.9
-MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
 ARG VERSION=4.3
 ARG user=jenkins

--- a/8/stretch/Dockerfile
+++ b/8/stretch/Dockerfile
@@ -21,7 +21,6 @@
 #  THE SOFTWARE.
 
 FROM openjdk:8-jdk-stretch
-MAINTAINER Oleg Nenashev <o.v.nenashev@gmail.com>
 
 ARG VERSION=4.3
 ARG user=jenkins

--- a/8/windows/nanoserver-1809/Dockerfile
+++ b/8/windows/nanoserver-1809/Dockerfile
@@ -22,20 +22,14 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG WINDOWS_DOCKER_TAG=1809
-ARG JAVA_VERSION=8u242-b08
-ARG JAVA_SHA256=8288e4d0983019706db89c153d18bfce28d033f646be65c8ae1c33c6c65b943e
-ARG JAVA_HOME=C:\jdk${JAVA_VERSION}
 # If you pass in a POWERSHELL_VERSION, make sure it ends with a hyphen, leaving it empty will
 # use the 'latest'
 ARG POWERSHELL_VERSION=
+FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-1809
 
-FROM mcr.microsoft.com/powershell:${POWERSHELL_VERSION}nanoserver-$WINDOWS_DOCKER_TAG
-MAINTAINER Alex Earl <slide.o.mix@gmail.com>
-
-ARG JAVA_VERSION
-ARG JAVA_SHA256
-ARG JAVA_HOME
+ARG JAVA_VERSION=8u242-b08
+ARG JAVA_SHA256=8288e4d0983019706db89c153d18bfce28d033f646be65c8ae1c33c6c65b943e
+ARG JAVA_HOME=C:\jdk${JAVA_VERSION}
 
 SHELL ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
@@ -50,9 +44,7 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
     Expand-Archive openjdk.zip -DestinationPath C:/ ; `
     Remove-Item -Path openjdk.zip
 
-ARG JAVA_HOME
-
-ARG VERSION=4.0.1
+ARG VERSION=4.3
 LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
 
 ARG GIT_VERSION=2.26.0

--- a/8/windows/windowsservercore-1809/Dockerfile
+++ b/8/windows/windowsservercore-1809/Dockerfile
@@ -22,10 +22,7 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 #  THE SOFTWARE.
 
-ARG WINDOWS_DOCKER_TAG=1809
-
-FROM adoptopenjdk:8-jdk-hotspot-windowsservercore-$WINDOWS_DOCKER_TAG
-MAINTAINER Alex Earl <slide.o.mix@gmail.com>
+FROM adoptopenjdk:8-jdk-hotspot-windowsservercore-1809
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 


### PR DESCRIPTION
- Cleanup MAINTAINER usage which is deprecated
- Fix JAVA_HOME for nanoserver
- Use 1809 for Windows OS version
- Update Windows tests similar to jnlp and ssh agents
- Change Windows tags to have jdk version at front when specified