### PR TITLE
Switch Debian images to Buster by default

### DIFF
--- a/8/buster/Dockerfile
+++ b/8/buster/Dockerfile
@@ -1,0 +1,50 @@
+# The MIT License
+#
+#  Copyright (c) 2015-2020, CloudBees, Inc. and other Jenkins contributors
+#
+#  Permission is hereby granted, free of charge, to any person obtaining a copy
+#  of this software and associated documentation files (the "Software"), to deal
+#  in the Software without restriction, including without limitation the rights
+#  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+#  copies of the Software, and to permit persons to whom the Software is
+#  furnished to do so, subject to the following conditions:
+#
+#  The above copyright notice and this permission notice shall be included in
+#  all copies or substantial portions of the Software.
+#
+#  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+#  THE SOFTWARE.
+
+FROM openjdk:8-jdk-buster
+
+ARG VERSION=4.3
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+
+RUN groupadd -g ${gid} ${group}
+RUN useradd -c "Jenkins user" -d /home/${user} -u ${uid} -g ${gid} -m ${user}
+LABEL Description="This is a base image, which provides the Jenkins agent executable (agent.jar)" Vendor="Jenkins project" Version="${VERSION}"
+
+ARG AGENT_WORKDIR=/home/${user}/agent
+
+RUN echo 'deb http://deb.debian.org/debian stretch-backports main' > /etc/apt/sources.list.d/stretch-backports.list
+RUN apt-get update && apt-get install -t stretch-backports git-lfs && rm -rf /var/lib/apt/lists/*
+RUN curl --create-dirs -fsSLo /usr/share/jenkins/agent.jar https://repo.jenkins-ci.org/public/org/jenkins-ci/main/remoting/${VERSION}/remoting-${VERSION}.jar \
+  && chmod 755 /usr/share/jenkins \
+  && chmod 644 /usr/share/jenkins/agent.jar \
+  && ln -sf /usr/share/jenkins/agent.jar /usr/share/jenkins/slave.jar
+
+USER ${user}
+ENV AGENT_WORKDIR=${AGENT_WORKDIR}
+RUN mkdir /home/${user}/.jenkins && mkdir -p ${AGENT_WORKDIR}
+
+VOLUME /home/${user}/.jenkins
+VOLUME ${AGENT_WORKDIR}
+WORKDIR /home/${user}

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ IMAGE_NAME:=jenkins4eval/agent
 IMAGE_NAME_AGENT:=jenkins4eval/slave
 
 .PHONY: build
-.PHONY: test test-alpine test-debian test-jdk11 test-jdk11-buster
+.PHONY: test test-alpine test-debian test-debian-buster test-jdk11 test-jdk11-buster
 
-build: build-alpine build-debian build-jdk11 build-jdk11-buster
+build: build-alpine build-debian build-debian-buster build-jdk11 build-jdk11-buster
 
 build-alpine:
 	docker build -t ${IMAGE_NAME}:alpine \
@@ -17,35 +17,43 @@ build-alpine:
 
 build-debian:
 	docker build -t ${IMAGE_NAME}:latest \
-                 -t ${IMAGE_NAME}:jdk8 \
                  -t ${IMAGE_NAME}:stretch \
                  -t ${IMAGE_NAME}:jdk8-stretch \
-                 -t ${IMAGE_NAME_AGENT}:latest \
                  8/stretch/
+
+build-debian-buster:
+	docker build -t ${IMAGE_NAME}:latest \
+                 -t ${IMAGE_NAME}:jdk8 \
+		 -t ${IMAGE_NAME}:jdk8-buster \
+                 -t ${IMAGE_NAME_AGENT}:latest \
+                 8/buster/
 
 build-jdk11:
 	docker build -t ${IMAGE_NAME}:jdk11 \
                  -t ${IMAGE_NAME}:jdk11-stretch \
-                 -t ${IMAGE_NAME_AGENT}:jdk11 \
                  11/stretch/
 
 build-jdk11-buster:
 	docker build -t ${IMAGE_NAME}:jdk11-buster \
-				 -t ${IMAGE_NAME_AGENT}:jdk11-buster \
-				 11/buster/
+                -t ${IMAGE_NAME_AGENT}:jdk11-buster \
+		-t ${IMAGE_NAME_AGENT}:jdk11 \
+                11/buster/
 
 bats:
 # The lastest version is v1.1.0
 	@if [ ! -d bats-core ]; then git clone https://github.com/bats-core/bats-core.git; fi
 	@git -C bats-core reset --hard c706d1470dd1376687776bbe985ac22d09780327
 
-test: test-alpine test-debian test-jdk11 test-jdk11-buster
+test: test-alpine test-debian test-debian-buster test-jdk11 test-jdk11-buster
 
 test-alpine: bats
 	@FOLDER="8/alpine" bats-core/bin/bats tests/tests.bats
 
 test-debian: bats
 	@FOLDER="8/stretch"   bats-core/bin/bats tests/tests.bats
+
+test-debian-buster: bats
+	@FOLDER="8/buster"   bats-core/bin/bats tests/tests.bats
 
 test-jdk11: bats
 	@FOLDER="11/stretch"  bats-core/bin/bats tests/tests.bats

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ build-debian:
 build-debian-buster:
 	docker build -t ${IMAGE_NAME}:latest \
                  -t ${IMAGE_NAME}:jdk8 \
-		 -t ${IMAGE_NAME}:jdk8-buster \
+                 -t ${IMAGE_NAME}:jdk8-buster \
                  -t ${IMAGE_NAME_AGENT}:latest \
                  8/buster/
 
@@ -36,7 +36,7 @@ build-jdk11:
 build-jdk11-buster:
 	docker build -t ${IMAGE_NAME}:jdk11-buster \
                 -t ${IMAGE_NAME_AGENT}:jdk11-buster \
-		-t ${IMAGE_NAME_AGENT}:jdk11 \
+                -t ${IMAGE_NAME_AGENT}:jdk11 \
                 11/buster/
 
 bats:

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ docker run -i --rm --name agent1 --init -v agent1-workdir:C:/Users/jenkins/Work 
 
 The image has several supported configurations, which can be accessed via the following tags:
 
-* `latest`: Latest version with the newest remoting (based on `openjdk:8-jdk`)
-* `latest-jdk11`: Latest version with the newest remoting and Java 11 (based on `openjdk:11-jdk`)
+* `latest`: Latest version with the newest remoting (based on `openjdk:8-jdk-buster`)
+* `latest-jdk11`: Latest version with the newest remoting and Java 11 (based on `openjdk:11-jdk-buster`)
 * `alpine`: Small image based on Alpine Linux (based on `openjdk:8-jdk-alpine`)
 * `jenkins4eval/agent:windowsservercore-1809`: Latest version with the newest remoting (based on `adoptopenjdk:8-jdk-hotspot-windowsservercore-1809`)
 * `jenkins4eval/agent:windowsservercore-1809-jdk11`: Latest version with the newest remoting and Java 11 (based on `adoptopenjdk:11-jdk-hotspot-windowsservercore-1809`)


### PR DESCRIPTION
Follow-up to https://github.com/jenkinsci/docker-slave/pull/105 by @krufab. The change adds Debian Buster image and switches both Java 8 and Java 11 images to Buster.
